### PR TITLE
Make sure verify and measurement report use the same rounding logic

### DIFF
--- a/lib/yardstick.rb
+++ b/lib/yardstick.rb
@@ -69,4 +69,17 @@ module Yardstick
     Processor.new(config).process_string(string)
   end
 
+  # Round percentage to 1/10th of a percent
+  #
+  # @param [Float] percentage
+  #   the percentage to round
+  #
+  # @return [Float]
+  #   the rounded percentage
+  #
+  # @api private
+  def self.round_percentage(percentage)
+    (percentage * 10).ceil / 10.0
+  end
+
 end # module Yardstick

--- a/lib/yardstick/measurement_set.rb
+++ b/lib/yardstick/measurement_set.rb
@@ -95,7 +95,7 @@ module Yardstick
     #
     # @api private
     def coverage_text
-      'YARD-Coverage: %.1f%%' % (coverage * 100)
+      'YARD-Coverage: %.1f%%' % Yardstick.round_percentage(coverage * 100)
     end
 
     # The text for the successful measurements to include in the summary

--- a/lib/yardstick/rake/verify.rb
+++ b/lib/yardstick/rake/verify.rb
@@ -68,7 +68,7 @@ module Yardstick
       # @api private
       def total_coverage
         measurements = Yardstick.measure(@config)
-        self.class.round_percentage(measurements.coverage * 100)
+        Yardstick.round_percentage(measurements.coverage * 100)
       end
 
     private
@@ -143,19 +143,6 @@ module Yardstick
       # @api private
       def higher_coverage?
         total_coverage > @threshold
-      end
-
-      # Round percentage to 1/10th of a percent
-      #
-      # @param [Float] percentage
-      #   the percentage to round
-      #
-      # @return [Float]
-      #   the rounded percentage
-      #
-      # @api private
-      def self.round_percentage(percentage)
-        (percentage * 10).ceil / 10.0
       end
 
     end # class Verify


### PR DESCRIPTION
I was getting a slightly different number in the measurement.txt report (99.3%) as opposed to what verify was telling me (99.2%)
