### PR TITLE
Support for overriding from a .yardstick.yml file or --config command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,20 @@ Every rule in Yardstick can be turned off globally and locally. All rules are en
 Default configuration:
 ```yaml
 ---
+# Minimum documentation coverage required for verifications to pass
 threshold: 100
+
+# Specify if the coverage summary should be displayed
+verbose: true
+
+# List of paths to measure. List may contain paths to files or globs
+path:
+  - lib/**/*.rb
+
+# Specify if the threshold should match the coverage
+require_exact_threshold: true
+
+# Rules that get applied to each source code file
 rules:
   ApiTag::Presence:
     enabled: true
@@ -126,6 +139,12 @@ rules:
     exclude: []
 ```
 
+#### Overriding Defaults
+
+Yardstick looks for a `.yardstick.yml` file in the project root for any
+project-specific config overrides. To adjust defaults, copy the above
+configuration to a file named `.yardstick.yml` and change as necessary.
+
 To disable a rule for some part of the code use:
 
 ```yaml
@@ -136,14 +155,6 @@ rules:
       - Foo::Bar  # class or module
       - Foo#bar   # instance method
       - Foo.bar   # class method
-```
-
-Rake tasks take these options as a second argument:
-
-```ruby
-options = YAML.load_file('config/yardstick.yml')
-
-Yardstick::Rake::Verify.new(:verify_measurements, options)
 ```
 
 ## Contributing

--- a/lib/yardstick/cli.rb
+++ b/lib/yardstick/cli.rb
@@ -33,9 +33,12 @@ module Yardstick
     #
     # @api private
     def self.parse_config(args)
-      args << '--help' if args.empty?
       option_parser.parse!(args)
-      Config.new(path: args)
+      if args.any?
+        Config.coerce(path: args)
+      else
+        Config.coerce({}) # Default path
+      end
     rescue OptionParser::InvalidOption => error
       display_exit(error)
     end

--- a/lib/yardstick/cli.rb
+++ b/lib/yardstick/cli.rb
@@ -8,7 +8,7 @@ module Yardstick
     # Parse the command line options, and run the command
     #
     # @example
-    #   Yardstick::CLI.run(%w[ article.rb ])  # => [ Measurement ]
+    #   Yardstick::CLI.run(*%w[ article.rb ])  # => [ Measurement ]
     #
     # @param [Array] args
     #   arguments passed in from the command line
@@ -33,11 +33,16 @@ module Yardstick
     #
     # @api private
     def self.parse_config(args)
-      option_parser.parse!(args)
-      if args.any?
-        Config.coerce(path: args)
+      options = {}
+      option_parser.parse!(args, into: options)
+
+      overrides = {}
+      overrides[:path] = args if args.any?
+
+      if options[:config]
+        Config.from_file(options[:config], overrides)
       else
-        Config.coerce({}) # Default path
+        Config.coerce(overrides)
       end
     rescue OptionParser::InvalidOption => error
       display_exit(error)
@@ -50,9 +55,18 @@ module Yardstick
     #
     # @api private
     def self.option_parser
-      opts = OptionParser.new
-      opts.on_tail('-v', '--version', 'print version information and exit') { display_exit("#{opts.program_name} #{VERSION}") }
-      opts.on_tail('-h', '--help',    'display this help and exit')         { display_exit(opts) }
+      @option_parser ||= OptionParser.new do |opts|
+        opts.on('-c FILE', '--config FILE', "load config file (default #{Yardstick::Config::DEFAULT_CONFIG_FILE})") do |file|
+          if File.exist?(file)
+            Pathname(file)
+          else
+            display_exit("Config file not found: #{file}")
+          end
+        end
+
+        opts.on_tail('-v', '--version', 'print version information and exit') { display_exit("#{opts.program_name} #{VERSION}") }
+        opts.on_tail('-h', '--help',    'display this help and exit')         { display_exit(opts) }
+      end
     end
 
     # Display a message and exit

--- a/lib/yardstick/measurement.rb
+++ b/lib/yardstick/measurement.rb
@@ -3,6 +3,13 @@
 module Yardstick
   # A measurement given a constraint on the docs
   class Measurement
+    # The wrapped yard docstring
+    #
+    # @return [Yardstick::Document]
+    #
+    # @api private
+    attr_reader :document
+
     # Return a Measurement instance
     #
     # @example

--- a/spec/fixtures/config1.yml
+++ b/spec/fixtures/config1.yml
@@ -1,0 +1,9 @@
+---
+threshold: 75.5
+path:
+  - lib/yardstick/document.rb
+rules:
+  ApiTag::Presence:
+    enabled: true
+    exclude:
+      - spec/foo/bar.rb

--- a/spec/unit/yardstick/config/class_methods/coerce_spec.rb
+++ b/spec/unit/yardstick/config/class_methods/coerce_spec.rb
@@ -29,4 +29,26 @@ describe Yardstick::Config, '.coerce' do
       expect(subject.path).to eql(new_path)
     end
   end
+
+  context 'when default config file exists' do
+    subject(:config) { described_class.coerce(hash) }
+
+    before do
+      allow(described_class)
+        .to receive(:default_config_file)
+        .and_return(Pathname('spec/fixtures/config1.yml'))
+    end
+
+    it 'includes configuration from the config file' do
+      expect(config.threshold).to eq 75.5
+    end
+
+    context 'when hash has conflicting keys with the config file' do
+      let(:hash) { { 'threshold' => 84.4 } }
+
+      it 'uses the value from the hash' do
+        expect(config.threshold).to eq 84.4
+      end
+    end
+  end
 end

--- a/spec/unit/yardstick/config/class_methods/from_file_spec.rb
+++ b/spec/unit/yardstick/config/class_methods/from_file_spec.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Yardstick::Config, '.from_file' do
+  subject(:config) { described_class.from_file(filename) }
+  let(:filename) { 'spec/fixtures/config1.yml' }
+
+  it 'loads configuration from the file' do
+    expect(config.threshold).to eq 75.5
+
+    # rules:
+    #   ApiTag::Presence:
+    #     enabled: true
+    #     exclude: ["spec/foo/bar.rb"]
+    rule = config.for_rule('Yardstick::Rules::ApiTag::Presence')
+    expect(rule.enabled_for_path?('lib/foo/bar.rb')).to be true
+    expect(rule.enabled_for_path?('spec/foo/bar.rb')).to be false
+  end
+
+  context  'when file does not exist' do
+    let(:filename) { 'spec/fixtures/does-not-exist.yml' }
+
+    it 'raises a File::NOENT exception' do
+      expect { config }.to raise_error(Errno::ENOENT)
+    end
+  end
+
+  context 'when overrides are specified' do
+    subject(:config) { described_class.from_file(filename, overrides) }
+    let(:overrides) { { "threshold" => 12.3 } }
+
+    it 'overrides values specified in the config file' do
+      expect(config.threshold).to eq 12.3
+    end
+  end
+
+  context 'when block provided' do
+    subject(:config) do
+      described_class.from_file(filename) do |config|
+        config.threshold = 33.3
+      end
+    end
+
+    it 'overrides values specified in the config file' do
+      expect(config.threshold).to eq 33.3
+    end
+  end
+end


### PR DESCRIPTION
This pull request fixes issue #24.

The pull request:
* adds support for loading default config overrides from a `.yardstick.yml` file
* makes providing a path to `yardstick` no longer required
* adds a command argument to specify the path to a custom config file

### Description
Support for the default config override should apply to the yardstick command, as well as rake files.  When looking for a default config, it searches up the directory tree until it finds either a `.yardstick.yml` or it reaches the bundler root directory where the `Gemfile` is usually kept.

The config override behavior is naive in that it does not attempt to perform a deep merge of the `rules` hash; there is currently no use case that would require a deep merge, as the hashes passed through `Yardstick#coerce` are never set to anything complicated within the gem.  The primary use case for deep merging rules would be projects that have had to work around not having a way to specify default overrides that have hacked up their Rakefile or written a wrapper script that sets the configuration manually.  Because passed hashes and code blocks take precedent, they should continue to work the same way as before this pull request.

Forcing the user to provide a path or set of paths when executing the `yardstick` command no longer makes sense as the path can be set in the `.yardstick.yml`; it would not be possible to use that value, and would always be overridden by the command line.  It is also inconsistent with the rake tasks that have no way to provide a path from the command line.  The path can still be specified, but has been made optional.

A `-c FILE` and `--config FILE` option was added to the `yardstick` command for specifying a custom configuration file.  If the option is given then the config file must exist or an error will be displayed.  If a custom config and exists, it is used instead of the `.yardstick.yml` file; it does not act as an override of the configuration within the default config file.

### Tests / Rubocop

Every attempt was made to include test coverage for all changes and simplecov still reports coverage at 100%.  Rubocop appears to non longer be working for the project due to changes in rubocop over time.  After resolving the hard failures encountered when running `bundle exec rake ci` due to configuration file changes, there were still a large number of unrelated offenses.  The rubocop fixes are outside the scope of this pull request and should be handled as a separate issues / pull request.